### PR TITLE
Image aspect ratio and autofill image dimensions

### DIFF
--- a/view/adminhtml/pagebuilder/content_type/image.xml
+++ b/view/adminhtml/pagebuilder/content_type/image.xml
@@ -8,7 +8,6 @@
                     <element name="desktop_image">
                         <attribute name="width" source="width"/>
                         <attribute name="height" source="height"/>
-                        <attribute name="preserve_aspect_ratio" source="preserve_aspect_ratio"/>
                         <attribute name="loading_mode"
                             reader="Melios_PageBuilder/js/image/content-type/loading-mode-reader"
                             persistence_mode="read"/>
@@ -32,7 +31,6 @@
                         <attribute name="use_mobile_dimensions" source="data-mls-use-sm-dimensions"/>
                         <attribute name="mobile_width" source="width"/>
                         <attribute name="mobile_height" source="height"/>
-                        <attribute name="mobile_preserve_aspect_ratio" source="mobile_preserve_aspect_ratio"/>
                         <attribute name="use_mobile_loading_mode" source="data-mls-use-sm-loading"/>
                         <attribute name="mobile_loading_mode"
                             reader="Melios_PageBuilder/js/image/content-type/loading-mode-reader"

--- a/view/adminhtml/pagebuilder/content_type/image.xml
+++ b/view/adminhtml/pagebuilder/content_type/image.xml
@@ -8,6 +8,7 @@
                     <element name="desktop_image">
                         <attribute name="width" source="width"/>
                         <attribute name="height" source="height"/>
+                        <attribute name="preserve_aspect_ratio" source="preserve_aspect_ratio"/>
                         <attribute name="loading_mode"
                             reader="Melios_PageBuilder/js/image/content-type/loading-mode-reader"
                             persistence_mode="read"/>
@@ -31,6 +32,7 @@
                         <attribute name="use_mobile_dimensions" source="data-mls-use-sm-dimensions"/>
                         <attribute name="mobile_width" source="width"/>
                         <attribute name="mobile_height" source="height"/>
+                        <attribute name="mobile_preserve_aspect_ratio" source="mobile_preserve_aspect_ratio"/>
                         <attribute name="use_mobile_loading_mode" source="data-mls-use-sm-loading"/>
                         <attribute name="mobile_loading_mode"
                             reader="Melios_PageBuilder/js/image/content-type/loading-mode-reader"

--- a/view/adminhtml/ui_component/pagebuilder_image_form.xml
+++ b/view/adminhtml/ui_component/pagebuilder_image_form.xml
@@ -8,6 +8,8 @@
                     <item name="config" xsi:type="array">
                         <item name="paths" xsi:type="array">
                             <item name="image" xsi:type="string">${ $.ns }.${ $.ns }.general.image</item>
+                            <item name="width" xsi:type="string">${ $.name }.width</item>
+                            <item name="height" xsi:type="string">${ $.name }.height</item>
                             <item name="preserveAspectRatio" xsi:type="string">${ $.name }.preserve_aspect_ratio</item>
                         </item>
                         <item name="links" xsi:type="array">
@@ -114,6 +116,8 @@
                     <item name="config" xsi:type="array">
                         <item name="paths" xsi:type="array">
                             <item name="image" xsi:type="string">${ $.ns }.${ $.ns }.general.mobile_image</item>
+                            <item name="width" xsi:type="string">${ $.name }.mobile_width</item>
+                            <item name="height" xsi:type="string">${ $.name }.mobile_height</item>
                             <item name="preserveAspectRatio" xsi:type="string">${ $.name }.mobile_preserve_aspect_ratio</item>
                         </item>
                         <item name="links" xsi:type="array">

--- a/view/adminhtml/ui_component/pagebuilder_image_form.xml
+++ b/view/adminhtml/ui_component/pagebuilder_image_form.xml
@@ -21,7 +21,7 @@
                 <field name="preserve_aspect_ratio" formElement="checkbox">
                     <argument name="data" xsi:type="array">
                         <item name="config" xsi:type="array">
-                            <item name="default" xsi:type="string">true</item>
+                            <item name="default" xsi:type="number">1</item>
                             <item name="elementTmpl" xsi:type="string">Melios_PageBuilder/image/aspect-ratio</item>
                         </item>
                     </argument>
@@ -37,8 +37,8 @@
                         <checkbox>
                             <settings>
                                 <valueMap>
-                                    <map name="false" xsi:type="string">false</map>
-                                    <map name="true" xsi:type="string">true</map>
+                                    <map name="false" xsi:type="number">0</map>
+                                    <map name="true" xsi:type="number">1</map>
                                 </valueMap>
                             </settings>
                         </checkbox>

--- a/view/adminhtml/ui_component/pagebuilder_image_form.xml
+++ b/view/adminhtml/ui_component/pagebuilder_image_form.xml
@@ -96,12 +96,7 @@
             </field>
         </container>
         <container name="mobile_image_attributes" sortOrder="3">
-            <container name="mobile_image_dimensions" component="Magento_Ui/js/form/components/group">
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="breakLine" xsi:type="boolean">false</item>
-                    </item>
-                </argument>
+            <container name="mobile_image_dimensions" component="Melios_PageBuilder/js/image/form/dimensions">
                 <field name="use_mobile_dimensions" formElement="checkbox">
                     <argument name="data" xsi:type="array">
                         <item name="config" xsi:type="array">
@@ -141,6 +136,36 @@
                             <link name="inheritedValue">ns = ${ $.ns }, index = width:value</link>
                         </imports>
                     </settings>
+                </field>
+                <field name="mobile_preserve_aspect_ratio" formElement="checkbox" component="Melios_PageBuilder/js/image/form/inherited-single-checkbox">
+                    <argument name="data" xsi:type="array">
+                        <item name="config" xsi:type="array">
+                            <item name="default" xsi:type="number">1</item>
+                            <item name="elementTmpl" xsi:type="string">Melios_PageBuilder/image/aspect-ratio</item>
+                        </item>
+                    </argument>
+                    <settings>
+                        <dataType>boolean</dataType>
+                        <label translate="true">Preserve aspect ratio</label>
+                        <additionalClasses>
+                            <class name="admin__field-small">true</class>
+                            <class name="mls-aspect-ratio">true</class>
+                        </additionalClasses>
+                        <imports>
+                            <link name="disabled">!ns = ${ $.ns }, index = use_mobile_dimensions:checked</link>
+                            <link name="inheritedValue">ns = ${ $.ns }, index = preserve_aspect_ratio:checked</link>
+                        </imports>
+                    </settings>
+                    <formElements>
+                        <checkbox>
+                            <settings>
+                                <valueMap>
+                                    <map name="false" xsi:type="number">0</map>
+                                    <map name="true" xsi:type="number">1</map>
+                                </valueMap>
+                            </settings>
+                        </checkbox>
+                    </formElements>
                 </field>
                 <field name="mobile_height" formElement="input" component="Melios_PageBuilder/js/image/form/inherited-input">
                     <settings>

--- a/view/adminhtml/ui_component/pagebuilder_image_form.xml
+++ b/view/adminhtml/ui_component/pagebuilder_image_form.xml
@@ -3,12 +3,7 @@
       xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <fieldset name="general">
         <container name="desktop_image_attributes" sortOrder="1">
-            <container name="image_dimensions" component="Magento_Ui/js/form/components/group">
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="breakLine" xsi:type="boolean">false</item>
-                    </item>
-                </argument>
+            <container name="image_dimensions" component="Melios_PageBuilder/js/image/form/dimensions">
                 <field name="width" formElement="input">
                     <settings>
                         <dataType>number</dataType>
@@ -22,6 +17,32 @@
                             <rule name="validate-number" xsi:type="boolean">true</rule>
                         </validation>
                     </settings>
+                </field>
+                <field name="preserve_aspect_ratio" formElement="checkbox">
+                    <argument name="data" xsi:type="array">
+                        <item name="config" xsi:type="array">
+                            <item name="default" xsi:type="string">true</item>
+                            <item name="elementTmpl" xsi:type="string">Melios_PageBuilder/image/aspect-ratio</item>
+                        </item>
+                    </argument>
+                    <settings>
+                        <dataType>boolean</dataType>
+                        <label translate="true">Preserve aspect ratio</label>
+                        <additionalClasses>
+                            <class name="admin__field-small">true</class>
+                            <class name="mls-aspect-ratio">true</class>
+                        </additionalClasses>
+                    </settings>
+                    <formElements>
+                        <checkbox>
+                            <settings>
+                                <valueMap>
+                                    <map name="false" xsi:type="string">false</map>
+                                    <map name="true" xsi:type="string">true</map>
+                                </valueMap>
+                            </settings>
+                        </checkbox>
+                    </formElements>
                 </field>
                 <field name="height" formElement="input">
                     <settings>

--- a/view/adminhtml/ui_component/pagebuilder_image_form.xml
+++ b/view/adminhtml/ui_component/pagebuilder_image_form.xml
@@ -4,6 +4,19 @@
     <fieldset name="general">
         <container name="desktop_image_attributes" sortOrder="1">
             <container name="image_dimensions" component="Melios_PageBuilder/js/image/form/dimensions">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="paths" xsi:type="array">
+                            <item name="image" xsi:type="string">${ $.ns }.${ $.ns }.general.image</item>
+                            <item name="preserveAspectRatio" xsi:type="string">${ $.name }.preserve_aspect_ratio</item>
+                        </item>
+                        <item name="links" xsi:type="array">
+                            <item name="width" xsi:type="string">${ $.provider }:data.width</item>
+                            <item name="height" xsi:type="string">${ $.provider }:data.height</item>
+                            <item name="preserveAspectRatio" xsi:type="string">${ $.provider }:data.preserve_aspect_ratio</item>
+                        </item>
+                    </item>
+                </argument>
                 <field name="width" formElement="input">
                     <settings>
                         <dataType>number</dataType>
@@ -97,6 +110,19 @@
         </container>
         <container name="mobile_image_attributes" sortOrder="3">
             <container name="mobile_image_dimensions" component="Melios_PageBuilder/js/image/form/dimensions">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="paths" xsi:type="array">
+                            <item name="image" xsi:type="string">${ $.ns }.${ $.ns }.general.mobile_image</item>
+                            <item name="preserveAspectRatio" xsi:type="string">${ $.name }.mobile_preserve_aspect_ratio</item>
+                        </item>
+                        <item name="links" xsi:type="array">
+                            <item name="width" xsi:type="string">${ $.provider }:data.mobile_width</item>
+                            <item name="height" xsi:type="string">${ $.provider }:data.mobile_height</item>
+                            <item name="preserveAspectRatio" xsi:type="string">${ $.provider }:data.mobile_preserve_aspect_ratio</item>
+                        </item>
+                    </item>
+                </argument>
                 <field name="use_mobile_dimensions" formElement="checkbox">
                     <argument name="data" xsi:type="array">
                         <item name="config" xsi:type="array">

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -95,7 +95,7 @@
     }
 }
 .mls-dimensions {
-    .admin__field-control {
+    .admin__field-small > .admin__field-control {
         width: 12rem !important;
     }
 }
@@ -110,7 +110,7 @@
     + div {
         padding-left: 7px !important;
     }
-    .admin__field-control {
+    &.admin__field-small > .admin__field-control {
         width: auto !important;
     }
     .admin__field-option {

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -117,6 +117,11 @@
     input[type="checkbox"] {
         inset: 0;
         margin: 0 !important;
+        &:disabled {
+            ~ svg {
+                opacity: .5;
+            }
+        }
     }
 }
 

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -96,7 +96,7 @@
 }
 .mls-dimensions {
     .admin__field-small > .admin__field-control {
-        width: 12rem !important;
+        width: 10.35rem !important;
     }
 }
 .mls-aspect-ratio {

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -96,6 +96,11 @@
 }
 .mls-aspect-ratio {
     width: 20px;
+    opacity: .8;
+    &:hover {
+        opacity: 1;
+    }
+
     &,
     + div {
         padding-left: 7px !important;

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -94,6 +94,11 @@
         content: '' !important;
     }
 }
+.mls-dimensions {
+    .admin__field-control {
+        width: 12rem !important;
+    }
+}
 .mls-aspect-ratio {
     width: 20px;
     opacity: .8;

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -94,6 +94,26 @@
         content: '' !important;
     }
 }
+.mls-aspect-ratio {
+    width: 20px;
+    &,
+    + div {
+        padding-left: 7px !important;
+    }
+    .admin__field-control {
+        width: auto !important;
+    }
+    .admin__field-option {
+        position: relative;
+        &:has(:focus-visible) {
+            &:extend(._keyfocus *:focus);
+        }
+    }
+    input[type="checkbox"] {
+        inset: 0;
+        margin: 0 !important;
+    }
+}
 
 // Mobile breakpoint notice
 .admin__field-mobile-breakpoint-notice {

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -53,14 +53,32 @@ define([
 
         onImageChange: function (image) {
             ko.getObservable(image[0], 'previewWidth')?.subscribe(width => {
-                this.ignoreAspectRatio = true;
-                this.width(width);
-                this.ignoreAspectRatio = false;
+                setTimeout(() => {
+                    var newRatio = Math.round(image[0].previewWidth / (image[0].previewHeight || 1)),
+                        oldRatio = Math.round(this.width() / (this.height() || 1));
+
+                    if (newRatio === oldRatio) {
+                        return;
+                    }
+
+                    this.ignoreAspectRatio = true;
+                    this.width(width);
+                    this.ignoreAspectRatio = false;
+                });
             });
             ko.getObservable(image[0], 'previewHeight')?.subscribe(height => {
-                this.ignoreAspectRatio = true;
-                this.height(height);
-                this.ignoreAspectRatio = false;
+                setTimeout(() => {
+                    var newRatio = Math.round(image[0].previewWidth / (image[0].previewHeight || 1)),
+                        oldRatio = Math.round(this.width() / (this.height() || 1));
+
+                    if (newRatio === oldRatio) {
+                        return;
+                    }
+
+                    this.ignoreAspectRatio = true;
+                    this.height(height);
+                    this.ignoreAspectRatio = false;
+                });
             });
         },
 

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -58,11 +58,24 @@ define([
 
             uiRegistry.get(this.paths['preserveAspectRatio'], checkbox => {
                 checkbox.checked(true);
+                checkbox.on('disabled', flag => {
+                    if (!flag) {
+                        checkbox.checked(true);
+                    }
+                });
             });
 
             uiRegistry.get(this.paths['width'], input => {
-                input.on('disabled', () => {
-                    this.aspectRatio = 0;
+                input.on('disabled', flag => {
+                    if (flag) {
+                        this.aspectRatio = 0;
+                    } else {
+                        setTimeout(() => {
+                            if (this.width() && this.height()) {
+                                this.aspectRatio = this.width() / this.height();
+                            }
+                        });
+                    }
                 });
             });
 

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -60,34 +60,52 @@ define([
                 checkbox.checked(true);
             });
 
+            uiRegistry.get(this.paths['width'], input => {
+                input.on('disabled', () => {
+                    this.aspectRatio = 0;
+                });
+            });
+
             return this;
         },
 
         onImageChange: function (image) {
             ko.getObservable(image[0], 'previewWidth')?.subscribe(width => {
-                setTimeout(() => {
-                    var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
-                        oldRatio = this.width() / (this.height() || 1);
+                uiRegistry.get(this.paths['width'], input => {
+                    setTimeout(() => {
+                        var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
+                            oldRatio = this.width() / (this.height() || 1);
 
-                    this.aspectRatio = newRatio;
-                    if (newRatio === oldRatio) {
-                        return;
-                    }
+                        if (input.disabled() && newRatio !== oldRatio) {
+                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
+                        }
 
-                    this.updateSizeIgnoringAspectRatio('width', width / 2);
+                        this.aspectRatio = newRatio;
+                        if (newRatio === oldRatio) {
+                            return;
+                        }
+
+                        this.updateSizeIgnoringAspectRatio('width', width / 2);
+                    });
                 });
             });
             ko.getObservable(image[0], 'previewHeight')?.subscribe(height => {
-                setTimeout(() => {
-                    var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
-                        oldRatio = this.width() / (this.height() || 1);
+                uiRegistry.get(this.paths['height'], input => {
+                    setTimeout(() => {
+                        var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
+                            oldRatio = this.width() / (this.height() || 1);
 
-                    this.aspectRatio = newRatio;
-                    if (newRatio === oldRatio) {
-                        return;
-                    }
+                        if (input.disabled() && newRatio !== oldRatio) {
+                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
+                        }
 
-                    this.updateSizeIgnoringAspectRatio('height', height / 2);
+                        this.aspectRatio = newRatio;
+                        if (newRatio === oldRatio) {
+                            return;
+                        }
+
+                        this.updateSizeIgnoringAspectRatio('height', height / 2);
+                    });
                 });
             });
         },

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -27,18 +27,20 @@ define([
 
             this.width.subscribe(newWidth => {
                 if (this.canPreserveAspectRatio() && newWidth) {
-                    this.ignoreAspectRatio = true;
-                    this.height(Math.round(newWidth / (this.oldWidth / this.oldHeight)));
-                    this.ignoreAspectRatio = false;
+                    this.updateSizeIgnoringAspectRatio(
+                        'height',
+                        Math.round(newWidth / (this.oldWidth / this.oldHeight))
+                    );
                 }
                 this.oldWidth = newWidth;
             });
 
             this.height.subscribe(newHeight => {
                 if (this.canPreserveAspectRatio() && newHeight) {
-                    this.ignoreAspectRatio = true;
-                    this.width(Math.round(newHeight * (this.oldWidth / this.oldHeight)));
-                    this.ignoreAspectRatio = false;
+                    this.updateSizeIgnoringAspectRatio(
+                        'width',
+                        Math.round(newHeight * (this.oldWidth / this.oldHeight))
+                    );
                 }
                 this.oldHeight = newHeight;
             });
@@ -61,9 +63,7 @@ define([
                         return;
                     }
 
-                    this.ignoreAspectRatio = true;
-                    this.width(width);
-                    this.ignoreAspectRatio = false;
+                    this.updateSizeIgnoringAspectRatio('width', width);
                 });
             });
             ko.getObservable(image[0], 'previewHeight')?.subscribe(height => {
@@ -75,9 +75,7 @@ define([
                         return;
                     }
 
-                    this.ignoreAspectRatio = true;
-                    this.height(height);
-                    this.ignoreAspectRatio = false;
+                    this.updateSizeIgnoringAspectRatio('height', height);
                 });
             });
         },
@@ -87,6 +85,12 @@ define([
                 && +this.preserveAspectRatio
                 && this.oldWidth
                 && this.oldHeight;
+        },
+
+        updateSizeIgnoringAspectRatio: function (side, value) {
+            this.ignoreAspectRatio = true;
+            this[side](value);
+            this.ignoreAspectRatio = false;
         }
     })
 });

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -110,12 +110,11 @@ define([
                         var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
                             oldRatio = this.width() / (this.height() || 1);
 
-                        if (input.disabled() && newRatio !== oldRatio) {
-                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
-                        }
-
                         this.aspectRatio = newRatio;
-                        if (newRatio === oldRatio) {
+
+                        if (input.disabled()) {
+                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
+                        } else if (newRatio === oldRatio) {
                             return;
                         }
 
@@ -129,12 +128,11 @@ define([
                         var newRatio = image[0].previewWidth / (image[0].previewHeight || 1),
                             oldRatio = this.width() / (this.height() || 1);
 
-                        if (input.disabled() && newRatio !== oldRatio) {
-                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
-                        }
-
                         this.aspectRatio = newRatio;
-                        if (newRatio === oldRatio) {
+
+                        if (input.disabled()) {
+                            uiRegistry.get(`${this.name}.use_mobile_dimensions`).checked(true);
+                        } else if (newRatio === oldRatio) {
                             return;
                         }
 

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -22,14 +22,20 @@ define([
                     return;
                 }
 
-                if (this.canPreserveAspectRatio()) {
-                    this.updateSizeIgnoringAspectRatio(
-                        'height',
-                        Math.round(newWidth / this.aspectRatio)
-                    );
-                } else if (!+this.preserveAspectRatio() && this.height()) {
-                    this.aspectRatio = newWidth / this.height();
-                }
+                uiRegistry.get(this.paths['width'], input => {
+                    if (input.disabled()) {
+                        return;
+                    }
+
+                    if (this.canPreserveAspectRatio()) {
+                        this.updateSizeIgnoringAspectRatio(
+                            'height',
+                            Math.round(newWidth / this.aspectRatio)
+                        );
+                    } else if (!+this.preserveAspectRatio() && this.height()) {
+                        this.aspectRatio = newWidth / this.height();
+                    }
+                });
             });
 
             this.height.subscribe(newHeight => {
@@ -37,14 +43,20 @@ define([
                     return;
                 }
 
-                if (this.canPreserveAspectRatio()) {
-                    this.updateSizeIgnoringAspectRatio(
-                        'width',
-                        Math.round(newHeight * this.aspectRatio)
-                    );
-                } else if (!+this.preserveAspectRatio() && this.width()) {
-                    this.aspectRatio = this.width() / newHeight;
-                }
+                uiRegistry.get(this.paths['height'], input => {
+                    if (input.disabled()) {
+                        return;
+                    }
+
+                    if (this.canPreserveAspectRatio()) {
+                        this.updateSizeIgnoringAspectRatio(
+                            'width',
+                            Math.round(newHeight * this.aspectRatio)
+                        );
+                    } else if (!+this.preserveAspectRatio() && this.width()) {
+                        this.aspectRatio = this.width() / newHeight;
+                    }
+                });
             });
 
             uiRegistry.get(this.paths['image'], image => {
@@ -56,6 +68,7 @@ define([
                 image.value.subscribe(this.onImageChange.bind(this));
             });
 
+            // preserve aspect ratio is not saved actually - check it when enabling
             uiRegistry.get(this.paths['preserveAspectRatio'], checkbox => {
                 checkbox.checked(true);
                 checkbox.on('disabled', flag => {
@@ -83,6 +96,14 @@ define([
         },
 
         onImageChange: function (image) {
+            if (!image[0]) {
+                this.updateSizeIgnoringAspectRatio('width', '');
+                this.updateSizeIgnoringAspectRatio('height', '');
+                uiRegistry.get(`${this.name}.use_mobile_dimensions`)?.checked(false);
+
+                return;
+            }
+
             ko.getObservable(image[0], 'previewWidth')?.subscribe(width => {
                 uiRegistry.get(this.paths['width'], input => {
                     setTimeout(() => {

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -11,11 +11,6 @@ define([
             breakLine: false,
             aspectRatio: 0,
             ignoreAspectRatio: false,
-            links: {
-                width: '${ $.provider }:data.width',
-                height: '${ $.provider }:data.height',
-                preserveAspectRatio: '${ $.provider }:data.preserve_aspect_ratio',
-            },
         },
 
         initObservable: function () {
@@ -52,7 +47,7 @@ define([
                 }
             });
 
-            uiRegistry.get(`${this.ns}.${this.ns}.general.image`, image => {
+            uiRegistry.get(this.paths['image'], image => {
                 setTimeout(() => {
                     if (!this.width() || !this.height()) {
                         this.onImageChange(image.value());
@@ -61,7 +56,7 @@ define([
                 image.value.subscribe(this.onImageChange.bind(this));
             });
 
-            uiRegistry.get(`${this.name}.preserve_aspect_ratio`, checkbox => {
+            uiRegistry.get(this.paths['preserveAspectRatio'], checkbox => {
                 checkbox.checked(true);
             });
 

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -1,0 +1,20 @@
+define([
+    'jquery',
+    'Magento_Ui/js/form/components/group'
+], function ($, Component) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            breakLine: false,
+        },
+
+        initialize: function () {
+            this._super();
+
+            console.log('hello');
+
+            return this;
+        }
+    })
+});

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -32,12 +32,14 @@ define([
                 ]);
 
             this.aspectRatio.subscribe(ratio => {
-                uiRegistry.get(this.paths['preserveAspectRatio'], checkbox => {
-                    var fraction = this.toReducedFraction(this.width(), this.height());
-                    $('#' + checkbox.uid).parent().attr(
-                        'title',
-                        $t('Preserve {ratio} aspect ratio').replace('{ratio}', fraction.join(':'))
-                    );
+                setTimeout(() => { // wait until width and height will be updated
+                    uiRegistry.get(this.paths['preserveAspectRatio'], checkbox => {
+                        var fraction = this.toReducedFraction(this.width(), this.height());
+                        $('#' + checkbox.uid).parent().attr(
+                            'title',
+                            $t('Preserve {ratio} aspect ratio').replace('{ratio}', fraction.join(':'))
+                        );
+                    });
                 });
             });
 

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -14,6 +14,14 @@ define([
             ignoreAspectRatio: false,
         },
 
+        initialize: function () {
+            this._super();
+
+            this.additionalClasses['mls-dimensions'] = true;
+
+            return this;
+        },
+
         initObservable: function () {
             this._super()
                 .observe([
@@ -164,7 +172,7 @@ define([
 
         updateSizeIgnoringAspectRatio: function (side, value) {
             if (value !== '') {
-                value = value % 1 === 0 ? value : value.toFixed(1);
+                value = value % 1 === 0 ? value : parseFloat(value.toFixed(1));
             }
 
             this.ignoreAspectRatio = true;

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -44,6 +44,14 @@ define([
             });
 
             this.width.subscribe(newWidth => {
+                if (newWidth?.includes?.('x')) {
+                    return setTimeout(() => {
+                        var [width, height] = newWidth.split('x');
+                        this.aspectRatio(width / height);
+                        this.width(width);
+                    });
+                }
+
                 if (isNaN(newWidth) || !newWidth) {
                     return;
                 }

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -79,7 +79,7 @@ define([
                         return;
                     }
 
-                    this.updateSizeIgnoringAspectRatio('width', width);
+                    this.updateSizeIgnoringAspectRatio('width', width / 2);
                 });
             });
             ko.getObservable(image[0], 'previewHeight')?.subscribe(height => {
@@ -92,7 +92,7 @@ define([
                         return;
                     }
 
-                    this.updateSizeIgnoringAspectRatio('height', height);
+                    this.updateSizeIgnoringAspectRatio('height', height / 2);
                 });
             });
         },

--- a/view/adminhtml/web/js/image/form/dimensions.js
+++ b/view/adminhtml/web/js/image/form/dimensions.js
@@ -1,20 +1,74 @@
 define([
     'jquery',
+    'ko',
+    'uiRegistry',
     'Magento_Ui/js/form/components/group'
-], function ($, Component) {
+], function ($, ko, uiRegistry, Component) {
     'use strict';
 
     return Component.extend({
         defaults: {
             breakLine: false,
+            oldWidth: 0,
+            oldHeight: 0,
+            ignoreAspectRatio: false,
+            links: {
+                width: '${ $.provider }:data.width',
+                height: '${ $.provider }:data.height',
+            },
+            imports: {
+                preserveAspectRatio: '${ $.provider }:data.preserve_aspect_ratio',
+            },
         },
 
-        initialize: function () {
-            this._super();
+        initObservable: function () {
+            this._super()
+                .observe(['width', 'height']);
 
-            console.log('hello');
+            this.width.subscribe(newWidth => {
+                if (this.canPreserveAspectRatio() && newWidth) {
+                    this.ignoreAspectRatio = true;
+                    this.height(Math.round(newWidth / (this.oldWidth / this.oldHeight)));
+                    this.ignoreAspectRatio = false;
+                }
+                this.oldWidth = newWidth;
+            });
+
+            this.height.subscribe(newHeight => {
+                if (this.canPreserveAspectRatio() && newHeight) {
+                    this.ignoreAspectRatio = true;
+                    this.width(Math.round(newHeight * (this.oldWidth / this.oldHeight)));
+                    this.ignoreAspectRatio = false;
+                }
+                this.oldHeight = newHeight;
+            });
+
+            uiRegistry.get(`${this.ns}.${this.ns}.general.image`, image => {
+                this.onImageChange(image.value());
+                image.value.subscribe(this.onImageChange.bind(this));
+            });
 
             return this;
+        },
+
+        onImageChange: function (image) {
+            ko.getObservable(image[0], 'previewWidth')?.subscribe(width => {
+                this.ignoreAspectRatio = true;
+                this.width(width);
+                this.ignoreAspectRatio = false;
+            });
+            ko.getObservable(image[0], 'previewHeight')?.subscribe(height => {
+                this.ignoreAspectRatio = true;
+                this.height(height);
+                this.ignoreAspectRatio = false;
+            });
+        },
+
+        canPreserveAspectRatio: function () {
+            return !this.ignoreAspectRatio
+                && +this.preserveAspectRatio
+                && this.oldWidth
+                && this.oldHeight;
         }
     })
 });

--- a/view/adminhtml/web/js/image/form/inherited-single-checkbox.js
+++ b/view/adminhtml/web/js/image/form/inherited-single-checkbox.js
@@ -1,0 +1,8 @@
+define([
+    'Magento_Ui/js/form/element/single-checkbox',
+    'Melios_PageBuilder/js/image/form/inherited-strategy'
+], function (Checkbox, strategy) {
+    'use strict';
+
+    return Checkbox.extend(strategy);
+});

--- a/view/adminhtml/web/js/image/form/inherited-strategy.js
+++ b/view/adminhtml/web/js/image/form/inherited-strategy.js
@@ -10,12 +10,16 @@ define([], function () {
         },
 
         onDisabledUpdate: function (flag) {
-            this.value(flag ? this.inheritedValue : this.initialValue);
+            var key = this.checked ? 'checked' : 'value';
+
+            this[key](flag ? this.inheritedValue : this.initialValue);
         },
 
         onInheritedValueUpdate: function (value) {
+            var key = this.checked ? 'checked' : 'value';
+
             if (this.disabled()) {
-                this.value(value);
+                this[key](value);
             }
         }
     };

--- a/view/adminhtml/web/template/image/aspect-ratio.html
+++ b/view/adminhtml/web/template/image/aspect-ratio.html
@@ -1,0 +1,16 @@
+<div class="admin__field admin__field-option" data-bind="attr: {title: $t('Preserve aspect ratio')}">
+    <input type="checkbox"
+           class="admin__control-checkbox"
+           ko-checked="$data.checked"
+           disable="disabled"
+           ko-value="value"
+           hasFocus="focused"
+           attr="id: uid, name: inputName"/>
+
+    <!-- ko if: checked -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" /></svg>
+    <!-- /ko -->
+    <!-- ko ifnot: checked -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z" /></svg>
+    <!-- /ko -->
+</div>


### PR DESCRIPTION
Features:

- Autofill dimensions in image upload/change (x2 smaller by default - for retina screens)
- Preserve aspect ratio when changing width/height
- Allow pasting both sides into the width field - `200x100`

<img src="https://github.com/user-attachments/assets/66a97482-014a-44ad-85d4-5dee406babcd" width="741" alt="screenshot"/>
