### PR TITLE
Allow drop elements into root-container

### DIFF
--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -48,6 +48,14 @@ var config = {
                 'Melios_PageBuilder/js/image-upload/media-uploader-mixin': true,
             },
 
+            // Wrap dropppable into RowContentType
+            'Magento_PageBuilder/js/drag-drop/matrix': {
+                'Melios_PageBuilder/js/make-droppable/matrix-mixin': true,
+            },
+            'Magento_PageBuilder/js/content-type-factory': {
+                'Melios_PageBuilder/js/make-droppable/content-type-factory-mixin': true,
+            },
+
             // BUGFIXES
             // Fixed incorrectly added 'no-column-line' class when pagebuilder is slowly rendered
             'Magento_PageBuilder/js/content-type/column-group/preview': {

--- a/view/adminhtml/web/js/make-droppable/content-type-factory-mixin.js
+++ b/view/adminhtml/web/js/make-droppable/content-type-factory-mixin.js
@@ -1,0 +1,47 @@
+define([
+    'mage/utils/wrapper',
+    'Magento_PageBuilder/js/config',
+    'Magento_PageBuilder/js/events'
+], function (wrapper, config, events) {
+    'use strict';
+
+    return function (target) {
+        return wrapper.wrap(target, function (o, ...args) {
+            var parentName = args[1]?.config.name;
+
+            // Wrap droppable into RowContentType if parent is not allowed
+            if (parentName &&
+                !args[0].allowed_parents.includes(parentName) &&
+                args[0].allowed_parents.includes('row')
+            ) {
+                var undroppableContentConfig = args[0];
+
+                args[0] = config.getConfig('content_types').row;
+
+                return o(...args).then(newParentContentType => {
+                    setTimeout(() => {
+                        args[0] = undroppableContentConfig;
+                        args[1] = newParentContentType;
+                        o(...args).then(newContent => {
+                            newParentContentType.addChild(newContent, 0);
+
+                            events.trigger('contentType:dropAfter', {
+                                id: newContent.id,
+                                contentType: newContent
+                            });
+
+                            events.trigger(undroppableContentConfig.name + ':dropAfter', {
+                                id: newContent.id,
+                                contentType: newContent
+                            });
+                        });
+                    });
+
+                    return newParentContentType;
+                });
+            }
+
+            return o(...args);
+        });
+    };
+});

--- a/view/adminhtml/web/js/make-droppable/matrix-mixin.js
+++ b/view/adminhtml/web/js/make-droppable/matrix-mixin.js
@@ -1,0 +1,32 @@
+define([
+    'mage/utils/wrapper'
+], function (wrapper) {
+    'use strict';
+
+    return function (target) {
+        target.getContainersFor = wrapper.wrap(target.getContainersFor, (o, contentType) => {
+            var containers = o(contentType);
+
+            if (containers.includes('row') && !containers.includes('root-container')) {
+                containers.push('root-container');
+            }
+
+            return containers;
+        });
+
+        target.getAllowedContainersClasses = wrapper.wrap(
+            target.getAllowedContainersClasses,
+            (o, contentType, stageId) => {
+                var classes = o(contentType, stageId);
+
+                if (target.getContainersFor(contentType).includes('root-container')) {
+                    classes += `, #${stageId} .content-type-container.root-container-container`
+                }
+
+                return classes;
+            }
+        );
+
+        return target;
+    };
+});

--- a/view/adminhtml/web/js/spotlight/page-builder-mixin.js
+++ b/view/adminhtml/web/js/spotlight/page-builder-mixin.js
@@ -3,10 +3,11 @@ define([
     'ko',
     'mage/utils/wrapper',
     'Magento_PageBuilder/js/events',
+    'Magento_PageBuilder/js/drag-drop/matrix',
     'Melios_PageBuilder/js/spotlight/spotlight',
     'Melios_PageBuilder/js/utils/can-use-hotkeys',
     'Melios_PageBuilder/js/utils/is-in-viewport'
-], function ($, ko, wrapper, events, spotlight, canUseHotkeys, isInViewport) {
+], function ($, ko, wrapper, events, matrix, spotlight, canUseHotkeys, isInViewport) {
     'use strict';
 
     var mouseCoords = {
@@ -355,7 +356,9 @@ define([
                                                         return false;
                                                     }
 
-                                                    return config.allowed_parents.includes(ko.dataFor(el)?.config.name);
+                                                    return matrix
+                                                        .getContainersFor(config.name)
+                                                        .includes(ko.dataFor(el)?.config.name);
                                                 })
                                         )
                                         .filter((i, el) => $(el).css('visibility') !== 'hidden')


### PR DESCRIPTION
If an element is not allowed inside RootContainer but allowed inside Row, Melios will automatically wrap it into RowContainer.
If an element is not allowed inside RowContainer, nothing will change.

