### PR TITLE
Sync changes from stage to opened modal

### DIFF
--- a/view/adminhtml/web/js/instant-preview/page-builder-mixin.js
+++ b/view/adminhtml/web/js/instant-preview/page-builder-mixin.js
@@ -52,7 +52,7 @@ define([
     });
 
     // Update form when switching view mode
-    var lastEdit, prevEdit;
+    var lastEdit, prevEdit, prevSyncFn;
     events.on('contentType:editBefore', (data) => {
         prevEdit = lastEdit;
         lastEdit = data.contentType;
@@ -69,11 +69,12 @@ define([
 
     // Update form data when inline editor inside preview stage is used
     function syncDataToModal(event, data) {
-        topModalUtils.updateModalData(data.state);
+        topModalUtils.updateModalData(data.state, this);
     }
     events.on('contentType:editBefore', (data) => {
-        prevEdit?.dataStore.events.off('state', syncDataToModal);
-        lastEdit.dataStore.events.on('state', syncDataToModal);
+        prevEdit?.dataStore.events.off('state', prevSyncFn);
+        prevSyncFn = syncDataToModal.bind(data.contentType)
+        lastEdit.dataStore.events.on('state', prevSyncFn);
     });
 
     // Close slideout when element is removed

--- a/view/adminhtml/web/js/instant-preview/page-builder-mixin.js
+++ b/view/adminhtml/web/js/instant-preview/page-builder-mixin.js
@@ -1,8 +1,9 @@
 define([
     'jquery',
     'knockout',
-    'Magento_PageBuilder/js/events'
-], function ($, ko, events) {
+    'Magento_PageBuilder/js/events',
+    'Melios_PageBuilder/js/instant-preview/top-modal-utils',
+], function ($, ko, events, topModalUtils) {
     'use strict';
 
     $('body').addClass('melios-instant-preview');
@@ -51,8 +52,11 @@ define([
     });
 
     // Update form when switching view mode
-    var lastEdit;
-    events.on('contentType:editBefore', (data) => { lastEdit = data.contentType; });
+    var lastEdit, prevEdit;
+    events.on('contentType:editBefore', (data) => {
+        prevEdit = lastEdit;
+        lastEdit = data.contentType;
+    });
     events.on('stage:viewportChangeAfter', () => {
         var popup = $('.pagebuilder_modal_form_pagebuilder_modal_form_modal._show');
 
@@ -61,6 +65,15 @@ define([
         }
 
         lastEdit.preview.openEdit();
+    });
+
+    // Update form data when inline editor inside preview stage is used
+    function syncDataToModal(event, data) {
+        topModalUtils.updateModalData(data.state);
+    }
+    events.on('contentType:editBefore', (data) => {
+        prevEdit?.dataStore.events.off('state', syncDataToModal);
+        lastEdit.dataStore.events.on('state', syncDataToModal);
     });
 
     // Close slideout when element is removed

--- a/view/adminhtml/web/js/instant-preview/top-modal-utils.js
+++ b/view/adminhtml/web/js/instant-preview/top-modal-utils.js
@@ -26,11 +26,11 @@ define([
             }
         }, 80),
 
-        updateModalData: _.throttle(data => {
+        updateModalData: _.throttle((data, contentType) => {
             var modal = topModal(),
                 topSource = ko.dataFor(modal.find('[name="appearance"]')[0])?.source;
 
-            if (!topSource) {
+            if (!topSource || topSource.id !== contentType.id) {
                 return;
             }
 
@@ -42,7 +42,7 @@ define([
                     allowUpdateModalSource = false;
                     topSource.set(`data.${k}`, v);
 
-                    if (el.wysiwygId &&
+                    if (el?.wysiwygId &&
                         tinyMCE.get(el.wysiwygId) &&
                         tinyMCE.get(el.wysiwygId).getContent() !== v
                     ) {

--- a/view/adminhtml/web/js/instant-preview/top-modal-utils.js
+++ b/view/adminhtml/web/js/instant-preview/top-modal-utils.js
@@ -5,6 +5,8 @@ define([
 ], function ($, _, ko) {
     'use strict';
 
+    var allowUpdateModalSource = true;
+
     function topModal() {
         return $('.modals-wrapper > ._show')
             .sort((a, b) => b.style.zIndex - a.style.zIndex)
@@ -19,21 +21,33 @@ define([
         updateSource: _.throttle(source => {
             var topSource = ko.dataFor(topModal().find('[name="appearance"]')[0])?.source;
 
-            if (topSource?.name === source?.name) {
+            if (allowUpdateModalSource && topSource?.name === source?.name) {
                 source?.save?.();
             }
         }, 80),
 
         updateModalData: _.throttle(data => {
-            var topSource = ko.dataFor(topModal().find('[name="appearance"]')[0])?.source;
+            var modal = topModal(),
+                topSource = ko.dataFor(modal.find('[name="appearance"]')[0])?.source;
 
             if (!topSource) {
                 return;
             }
 
+            setTimeout(() => allowUpdateModalSource = true, 100);
             _.each(data, (v, k) => {
                 if (typeof v === 'string' && topSource.data[k] !== v) {
+                    var el = ko.dataFor(modal.find(`[name="${k}"]`).closest('[data-bind]')[0]);
+
+                    allowUpdateModalSource = false;
                     topSource.set(`data.${k}`, v);
+
+                    if (el.wysiwygId &&
+                        tinyMCE.get(el.wysiwygId) &&
+                        tinyMCE.get(el.wysiwygId).getContent() !== v
+                    ) {
+                        tinyMCE.get(el.wysiwygId).setContent(v);
+                    }
                 }
             });
         }, 80),

--- a/view/adminhtml/web/js/instant-preview/top-modal-utils.js
+++ b/view/adminhtml/web/js/instant-preview/top-modal-utils.js
@@ -5,7 +5,8 @@ define([
 ], function ($, _, ko) {
     'use strict';
 
-    var allowUpdateModalSource = true;
+    var allowUpdateModalSource = true,
+        allowUpdateModalSourceTimer;
 
     function topModal() {
         return $('.modals-wrapper > ._show')
@@ -26,7 +27,7 @@ define([
             }
         }, 80),
 
-        updateModalData: _.throttle((data, contentType) => {
+        updateModalData: (data, contentType) => {
             var modal = topModal(),
                 topSource = ko.dataFor(modal.find('[name="appearance"]')[0])?.source;
 
@@ -34,7 +35,8 @@ define([
                 return;
             }
 
-            setTimeout(() => allowUpdateModalSource = true, 100);
+            clearTimeout(allowUpdateModalSourceTimer);
+            allowUpdateModalSourceTimer = setTimeout(() => allowUpdateModalSource = true, 100);
             _.each(data, (v, k) => {
                 if (typeof v === 'string' && topSource.data[k] !== v) {
                     var el = ko.dataFor(modal.find(`[name="${k}"]`).closest('[data-bind]')[0]);
@@ -50,6 +52,6 @@ define([
                     }
                 }
             });
-        }, 80),
+        },
     }
 });

--- a/view/adminhtml/web/js/instant-preview/top-modal-utils.js
+++ b/view/adminhtml/web/js/instant-preview/top-modal-utils.js
@@ -23,5 +23,15 @@ define([
                 source?.save?.();
             }
         }, 80),
+
+        updateModalData: _.throttle(data => {
+            var topSource = ko.dataFor(topModal().find('[name="appearance"]')[0])?.source;
+
+            _.each(data, (v, k) => {
+                if (typeof v === 'string' && topSource.data[k] !== v) {
+                    topSource.set(`data.${k}`, v);
+                }
+            });
+        }, 80),
     }
 });

--- a/view/adminhtml/web/js/instant-preview/top-modal-utils.js
+++ b/view/adminhtml/web/js/instant-preview/top-modal-utils.js
@@ -27,6 +27,10 @@ define([
         updateModalData: _.throttle(data => {
             var topSource = ko.dataFor(topModal().find('[name="appearance"]')[0])?.source;
 
+            if (!topSource) {
+                return;
+            }
+
             _.each(data, (v, k) => {
                 if (typeof v === 'string' && topSource.data[k] !== v) {
                     topSource.set(`data.${k}`, v);

--- a/view/adminhtml/web/js/wysiwyg/wysiwyg-tinymce-mixin.js
+++ b/view/adminhtml/web/js/wysiwyg/wysiwyg-tinymce-mixin.js
@@ -17,7 +17,7 @@ define([
         function onSelectionChange(e) {
             var caretRect = editor?.selection.getRng().getBoundingClientRect();
 
-            if (!caretRect.height) {
+            if (!caretRect?.height) {
                 caretRect = editor?.selection.getRng().startContainer?.getBoundingClientRect();
             }
 


### PR DESCRIPTION
This PR fixes non-saved WYSIWYG changes when edit modal is opened, but user edit the value directly on the stage (using inline editor)